### PR TITLE
* Remove deprecated dependency on the libraries API module

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ Highlighter, written by Nigel McNie) which can be found at
   http://qbnz.com/highlighter
 See installation procedure below for more information.
 
-This module requires that the following modules are also enabled:
-
-  * [Libraries API](https://backdropcms.org/project/libraries)
-
-
 Installation
 ------------
 
@@ -44,7 +39,7 @@ GeSHi Filter
   from the branch 1.1.x (also described as geshi-dev), which is not yet
   supported by the GeSHi filter module.
   Place the entire extracted 'geshi' folder (which contains geshi.php)
-  in a libraries directory (typically /libraries/geshi).
+  in the libraries directory of this module (./libraries/geshi).
 
 GeSHi Fields
 

--- a/geshifilter.admin.inc
+++ b/geshifilter.admin.inc
@@ -60,9 +60,6 @@ function geshifilter_admin_general_settings($form, &$form_state) {
   $form = array();
   $form['#config'] = 'geshifilter.settings';
 
-  // Try to load GeSHi library and get version if successful.
-  $geshi_library = libraries_load('geshi');
-
   $form['geshifilter_help'] = array(
     '#type' => 'help',
     '#markup' => '<p>' . t('The GeSHi filter module provides a filter for syntax highlighting of inline source code or blocks of source code based on the PHP library !GeSHi.', array('!GeSHi' => l('GeSHi (Generic Syntax Highlighter)', 'http://qbnz.com/highlighter/'))) . '</p>'
@@ -80,11 +77,11 @@ function geshifilter_admin_general_settings($form, &$form_state) {
     '#description' => t('The GeSHi filter requires the GeSHi library (which needs to be <a href="!geshi">downloaded</a> and installed seperately).',
       array('!geshi' => url('http://qbnz.com/highlighter/'))),
     '#collapsible' => TRUE,
-    '#collapsed' => $geshi_library['loaded'],
+    '#collapsed' => class_exists('GeSHi'),
   );
 
   // If the GeSHi library is loaded, show all the options and settings.
-  if ($geshi_library['loaded']) {
+  if (class_exists('GeSHi')) {
 
     // Option for flushing the GeSHi language definition cache.
     $form['geshifilter_library_info']['geshi_language_definition_caching'] = array(
@@ -263,10 +260,8 @@ function geshifilter_admin_general_settings_submit($form, &$form_state) {
  * Menu callback for per language settings.
  */
 function geshifilter_admin_per_language_settings($form, &$form_state, $view = 'enabled') {
-  // check if GeSHi library is available
-  $geshi_library = libraries_load('geshi');
-  if (!$geshi_library['loaded']) {
-    backdrop_set_message($geshi_library['error message'], 'error');
+  if (!class_exists('GeSHi')) {
+    backdrop_set_message('Could not load GeSHi library.', 'error');
     return;
   }
   $add_checkbox = TRUE;
@@ -605,8 +600,7 @@ function _geshifilter_clear_filter_cache() {
  */
 function _geshifilter_generate_languages_css_rules() {
   $output = '';
-  $geshi_library = libraries_load('geshi');
-  if ($geshi_library['loaded']) {
+  if (class_exists('GeSHi')) {
     require_once backdrop_get_path('module', 'geshifilter') . '/geshifilter.pages.inc';
     $languages = _geshifilter_get_enabled_languages();
     foreach ($languages as $langcode => $language_full_name) {

--- a/geshifilter.conflicts.inc
+++ b/geshifilter.conflicts.inc
@@ -15,11 +15,9 @@ function geshifilter_admin_filter_conflicts($check_only = FALSE) {
 
   // start
   $output = '';
-  // check if GeSHi library is available
-  $geshi_library = libraries_load('geshi');
-  if (!$geshi_library['loaded']) {
+  if (!class_exists('GeSHi')) {
     if (!$check_only) {
-      backdrop_set_message($geshi_library['error message'], 'error');
+      backdrop_set_message('Could not load GeSHi library.', 'error');
     }
     return $output;
   }

--- a/geshifilter.inc
+++ b/geshifilter.inc
@@ -15,10 +15,9 @@ function _geshifilter_get_available_languages() {
   $available_languages = config_get('geshifilter.settings', 'geshifilter_available_languages_cache');
   if ($available_languages === NULL) {
     // not in cache: build the array of available_languages
-    $geshi_library = libraries_load('geshi');
     $available_languages = array();
-    if ($geshi_library['loaded']) {
-      $dirs = array($geshi_library['library path'] . '/geshi', backdrop_get_path('module', 'geshifilter') . '/geshi-extra');
+    if (class_exists('GeSHi')) {
+      $dirs = array(backdrop_get_path('module', 'geshifilter') . '/libraries/geshi/geshi', backdrop_get_path('module', 'geshifilter') . '/geshi-extra');
       foreach ($dirs as $dir) {
         foreach (file_scan_directory($dir, '/.[pP][hH][pP]$/i') as $filename => $fileinfo) {
           // short name

--- a/geshifilter.info
+++ b/geshifilter.info
@@ -3,6 +3,4 @@ description = Provides a filter to highlight source code using the GeSHi library
 package = Filters
 backdrop = 1.x
 type = module
-php = 7.4
 configure = admin/config/content/formats/geshifilter
-dependencies[] = libraries

--- a/geshifilter.install
+++ b/geshifilter.install
@@ -84,3 +84,19 @@ function geshifilter_update_1000() {
   update_variable_del('geshifilter_language_tags_language');
   update_variable_del('geshifilter_language_tags_language_format');
 }
+
+/**
+ * Move the geshifilter library, if it existed before.
+ */
+function geshifilter_update_1001() {
+  //path recommended by previous documentation
+  $old_path = BACKDROP_ROOT . '/libraries/geshi';
+  $new_path = BACKDROP_ROOT . '/' . backdrop_get_path('module', 'geshifilter') . '/libraries/geshi';
+  $file_moved = false;
+  if (file_exists($old_path)) {
+    $files_moved = rename($old_path, $new_path);
+  }
+  if (!$files_moved) {
+    return t('Unable to locate or move GeSHi library. Place the library in the geshifilter/libraries directory.');
+  }
+}

--- a/geshifilter.module
+++ b/geshifilter.module
@@ -201,9 +201,7 @@ function geshifilter_requirements($phase) {
   $requirements = array();
   if ($phase == 'runtime') {
     require_once __DIR__ . '/geshifilter.inc';
-    // Check if GeSHi library is available.
-    $geshi_library = libraries_load('geshi');
-    if (!$geshi_library['loaded']) {
+    if (!class_exists('GeSHi')) {
       $requirements[] = array(
         'title' => 'GeSHi filter',
         'value' => t('GeSHi library not found.'),
@@ -254,29 +252,6 @@ function geshifilter_requirements($phase) {
     }
   }
   return $requirements;
-}
-
-/**
- * Implements hook_libraries_info().
- */
-function geshifilter_libraries_info() {
-  return array(
-    'geshi' => array(
-      'title' => 'GeSHi - Generic Syntax Highlighter for PHP',
-      'vendor url' => 'http://sourceforge.net/projects/geshi',
-      'download url' => 'http://sourceforge.net/projects/geshi/files/geshi',
-      'version arguments' => array(
-        'file' => 'geshi.php',
-        'pattern' => "/define\('GESHI_VERSION', '(.*)'\);/",
-        'lines' => 50,
-      ),
-      'files' => array(
-        'php' => array(
-          'geshi.php',
-        ),
-      ),
-    ),
-  );
 }
 
 /**
@@ -340,6 +315,8 @@ function geshifilter_form_filter_admin_format_form_alter(&$form, &$form_state, $
  * Implements hook_autoload_info().
  */
 function geshifilter_autoload_info() {
-  return array(
-  );
+  return [
+    'GeSHi' => 'libraries/geshi/geshi.php'
+  ];
 }
+

--- a/geshifilter.pages.inc
+++ b/geshifilter.pages.inc
@@ -234,11 +234,8 @@ function _geshifilter_prepare_php_callback($match, $format) {
  * Geshifilter_filter callback for processing input text.
  */
 function _geshifilter_process($format, $text, $filter) {
-  // Load GeSHi library (if not already).
-  $geshi_library = libraries_load('geshi');
-
-  if (!$geshi_library['loaded']) {
-    backdrop_set_message($geshi_library['error message'], 'error');
+  if (!class_exists('GeSHi')) {
+    backdrop_set_message('Could not load GeSHi library.', 'error');
     return $text;
   }
   // Get the available tags.
@@ -360,10 +357,8 @@ function geshifilter_process_sourcecode($source_code, $lang, $line_numbering = 0
  */
 function geshifilter_geshi_process($source_code, $lang, $line_numbering = 0, $linenumbers_start = 1, $inline_mode = FALSE, $title = NULL) {
   $config = config('geshifilter.settings');
-  // load GeSHi library (if not already)
-  $geshi_library = libraries_load('geshi');
-  if (!$geshi_library['loaded']) {
-    backdrop_set_message($geshi_library['error message'], 'error');
+  if (!class_exists('GeSHi')) {
+    backdrop_set_message('Could not load GeSHi library.', 'error');
     return $source_code;
   }
 

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -1,0 +1,11 @@
+- This module requires the third-party library GeShi 1.0.x (Generic Syntax
+Highlighter, written by Nigel McNie) which can be found at
+  http://qbnz.com/highlighter
+
+- Download the GeSHi library from
+https://sourceforge.net/projects/geshi/files/geshi/
+Make sure you download a version of the branch 1.0.x and not a version
+from the branch 1.1.x (also described as geshi-dev), which is not yet
+supported by the GeSHi filter module.
+Place the entire extracted 'geshi' folder (which contains geshi.php)
+in this directory.


### PR DESCRIPTION
* Update inclusion of GeSHi class, this isn't really a javascript library and should be loaded like a class instead.
* Update installer to move GeSHi library if it was found in the old recommended location, or warn user
* Update README with new install paths

Resolves issue #5